### PR TITLE
[fix] Non-English character fix

### DIFF
--- a/mod/config.rpy
+++ b/mod/config.rpy
@@ -101,7 +101,8 @@ init 90 python in fom_presence:
         @staticmethod
         def load_file(path):
             c = configparser.ConfigParser()
-            c.read(path)
+            with open(path, "r", encoding="utf-8") as f:
+                c.readfp(f, path.replace("\\", "/").split("/")[:-1])
             return Config(c)
 
         @property

--- a/mod/config.rpy
+++ b/mod/config.rpy
@@ -18,6 +18,7 @@ init 90 python in fom_presence:
 
     if sys.version_info.major == 2:
         import ConfigParser as configparser
+        import io
     else:
         import configparser
 
@@ -101,7 +102,7 @@ init 90 python in fom_presence:
         @staticmethod
         def load_file(path):
             c = configparser.ConfigParser()
-            with open(path, "r", encoding="utf-8") as f:
+            with _open_encoding(path, "r", encoding="utf-8") as f:
                 c.readfp(f, path.replace("\\", "/").split("/")[:-1])
             return Config(c)
 

--- a/mod/util.rpy
+++ b/mod/util.rpy
@@ -16,6 +16,8 @@ init -1000 python in fom_presence:
 
     import os
     import datetime
+    import io
+    import sys
 
 
     def _get_script_file(fallback=None, relative=False):
@@ -145,3 +147,11 @@ init -1000 python in fom_presence:
 
         def get(self, *args, **kwargs):
             return self._provide(*args, **kwargs)
+
+
+    if sys.version_info.major == 2:
+        def _open_encoding(path, mode, encoding="utf-8"):
+            return io.open(path, "r", encoding="utf-8")
+    else:
+        def _open_encoding(path, mode, encoding="utf-8"):
+            return open(path, "r", encoding="utf-8")


### PR DESCRIPTION
*The following uses a translator.*

When I tested it, I got garbled using non-English characters, I presume it was caused by encoding problems, so I used utf-8 encoding when reading the configuration.

Note: py3 onwards should not need `import io`